### PR TITLE
docs: add restaking dashboard links

### DIFF
--- a/docs/operators/faqs.md
+++ b/docs/operators/faqs.md
@@ -29,3 +29,9 @@ Yes, node operators must have economic security delegation on the SSP to partici
 6. **How are Rewards distributed to Node Operators?**
 
 Rewards are distributed directly by the SSPs. If you’re running a Catalysis-Powered AVS (say $100M) secured by EigenLayer ($50M) + Symbiotic ($50M), you’ll receive separate payouts from both EigenLayer and Symbiotic based on your stake and participation.
+
+7. **Do we need to partner with LRTs to run networks on a Shared Security Protocol (SSP)?**
+
+No, you don’t need to partner with LRTs directly. Catalysis partners with top LRTs and vault curators across SSPs, allowing you to seamlessly run Networks without separate LRT agreements.
+
+However, if you already have LRT partnerships, it can streamline delegation and integration, making the process even smoother.

--- a/docs/resources/references.md
+++ b/docs/resources/references.md
@@ -8,6 +8,8 @@ The following is a list of references that you can visit for more details.
 - Restaking Dashboards
   - [Restake watch](https://restake.watch/)
   - [U--1](https://u--1.com/)
+  - [Inception LRT Dashboard](https://inceptionlrt.com/restaking-explorer)
+  - [Dune Dashboard](https://dune.com/blocklytics/ethereum-restaking)
 - Docs
   - [Eigenlayer](https://docs.eigenlayer.xyz/)
   - [Symbiotic](https://docs.symbiotic.fi/)


### PR DESCRIPTION
Adds the following:
- Links to new restaking dashboards (inception lrt, dune)
- Add one node operator faq